### PR TITLE
Ubuntu-based Relayer Docker image

### DIFF
--- a/docker/relayer/Dockerfile
+++ b/docker/relayer/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt install -y nodejs
 
 # Copy everything into place for the relayer
-RUN apt install -y bash jq
+RUN apt install -y bash jq netcat
 COPY --from=build-stage /app/dist/ /app/dist
 COPY --from=module-install-stage /app/node_modules/ /app/node_modules
 COPY --from=module-install-stage /app/scripts/ /app/scripts


### PR DESCRIPTION
This PR replaces the Alpine-based Docker image with an Ubuntu 22.04-based Docker image.