### PR TITLE
Zy0n/add fees by token

### DIFF
--- a/src/models/network-models.ts
+++ b/src/models/network-models.ts
@@ -6,7 +6,6 @@ import {
 import { CoingeckoNetworkID } from './api-constants';
 import { FallbackProviderJsonConfig } from './provider-models';
 import { GasTokenConfig } from './token-models';
-import { FeeConfig } from './fee-config';
 
 export type Network = {
   name: string;
@@ -17,7 +16,6 @@ export type Network = {
   gasToken: GasTokenConfig;
   coingeckoNetworkId?: CoingeckoNetworkID;
   priceTTLInMS: number;
-  fees: FeeConfig;
   isTestNetwork?: boolean;
   skipQuickScan?: boolean;
 };

--- a/src/models/token-models.ts
+++ b/src/models/token-models.ts
@@ -1,5 +1,6 @@
 import { BaseTokenWrappedAddress } from '@railgun-community/shared-models';
 import { BigNumber } from 'ethers';
+import { FeeConfig } from './fee-config';
 
 export const GAS_TOKEN_DECIMALS = 18;
 
@@ -14,6 +15,7 @@ export type GasTokenConfig = {
 
 export type TokenConfig = {
   symbol: string;
+  fee: FeeConfig;
 };
 
 export type Token = TokenConfig & {

--- a/src/server/config/__tests__/config-token-price-getter.test.ts
+++ b/src/server/config/__tests__/config-token-price-getter.test.ts
@@ -12,6 +12,7 @@ import {
 import configNetworks from '../config-networks';
 import configTokenPriceRefresher from '../config-token-price-refresher';
 import configTokens from '../config-tokens';
+import { feeConfigL1 } from '../config-fees';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -30,6 +31,7 @@ describe('config-token-price-refresher', () => {
     configTokens[MOCK_CHAIN.type][MOCK_CHAIN.id] ??= {};
     configTokens[MOCK_CHAIN.type][MOCK_CHAIN.id][MOCK_TOKEN_ADDRESS] = {
       symbol: 'MOCK',
+      fee: feeConfigL1(1.1),
     };
     await initTokens();
   });

--- a/src/server/config/config-fees.ts
+++ b/src/server/config/config-fees.ts
@@ -1,13 +1,25 @@
 import { FeeConfig } from '../../models/fee-config';
 import configDefaults from './config-defaults';
 
+const feeConfig = (
+  gasEstimateLimitToActualRatio: number,
+  gasEstimateVarianceBuffer: number,
+  profit: number,
+): FeeConfig => ({
+  gasEstimateLimitToActualRatio,
+  gasEstimateVarianceBuffer,
+  profit,
+});
+
 export const feeConfigL1 = (
   gasEstimateLimitToActualRatio: number,
-): FeeConfig => ({
-  gasEstimateVarianceBuffer: 0.0,
-  gasEstimateLimitToActualRatio,
-  profit: configDefaults.transactionFees.profitMargin,
-});
+  gasEstimateVarianceBuffer = 0.0,
+): FeeConfig =>
+  feeConfig(
+    gasEstimateLimitToActualRatio,
+    gasEstimateVarianceBuffer,
+    configDefaults.transactionFees.profitMargin,
+  );
 
 /**
  * Default fee config for L2 networks.
@@ -15,10 +27,13 @@ export const feeConfigL1 = (
  * This gas estimation difference is only relevant on L2s.
  * If gas doesn't spike to this degree, this buffer becomes profit.
  */
+
 export const feeConfigL2 = (
   gasEstimateLimitToActualRatio: number,
-): FeeConfig => ({
-  gasEstimateVarianceBuffer: 0.3,
-  gasEstimateLimitToActualRatio,
-  profit: configDefaults.transactionFees.profitMargin,
-});
+  gasEstimateVarianceBuffer = 0.3,
+): FeeConfig =>
+  feeConfig(
+    gasEstimateLimitToActualRatio,
+    gasEstimateVarianceBuffer,
+    configDefaults.transactionFees.profitMargin,
+  );

--- a/src/server/config/config-networks.ts
+++ b/src/server/config/config-networks.ts
@@ -6,7 +6,6 @@ import fallbackProvidersArbitrum from './fallback-providers/42161-arbitrum';
 import fallbackProvidersPolygonMumbai from './fallback-providers/80001-polygon-mumbai';
 import fallbackProvidersHardhat from './fallback-providers/31337-hardhat';
 import fallbackProvidersArbitrumGoerli from './fallback-providers/421613-arbitrum-goerli';
-import { feeConfigL1, feeConfigL2 } from './config-fees';
 import { CoingeckoNetworkID } from '../../models/api-constants';
 import {
   BaseTokenWrappedAddress,
@@ -21,6 +20,7 @@ import { NO_GAS_TOKEN_ADDRESS } from '../../models/token-models';
 
 // 0.15 ETH minimum for L1 availability.
 const MINIMUM_BALANCE_FOR_AVAILABILITY_L1 = 0.15;
+
 // 0.01 ETH minimum for L2 availability.
 const MINIMUM_BALANCE_FOR_AVAILABILITY_L2 = 0.01;
 
@@ -38,7 +38,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L1,
       },
-      fees: feeConfigL1(1.25),
       proxyContract: RailgunProxyContract.Ethereum,
       relayAdaptContract: RelayAdaptContract.Ethereum,
       deploymentBlock: RailgunProxyDeploymentBlock.Ethereum,
@@ -54,7 +53,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L1,
       },
-      fees: feeConfigL1(1.25),
       proxyContract: RailgunProxyContract.EthereumGoerli,
       relayAdaptContract: RelayAdaptContract.EthereumGoerli,
       deploymentBlock: RailgunProxyDeploymentBlock.EthereumGoerli,
@@ -70,7 +68,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L1,
       },
-      fees: feeConfigL1(1.2),
       proxyContract: RailgunProxyContract.BNBChain,
       relayAdaptContract: RelayAdaptContract.BNBChain,
       deploymentBlock: RailgunProxyDeploymentBlock.BNBChain,
@@ -86,7 +83,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L1,
       },
-      fees: feeConfigL1(1.15),
       proxyContract: RailgunProxyContract.PolygonPOS,
       relayAdaptContract: RelayAdaptContract.PolygonPOS,
       coingeckoNetworkId: CoingeckoNetworkID.PolygonPOS,
@@ -102,7 +98,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L2,
       },
-      fees: feeConfigL2(1.5),
       proxyContract: RailgunProxyContract.Arbitrum,
       relayAdaptContract: RelayAdaptContract.Arbitrum,
       coingeckoNetworkId: CoingeckoNetworkID.Arbitrum,
@@ -118,7 +113,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L1,
       },
-      fees: feeConfigL1(1.15),
       proxyContract: RailgunProxyContract.PolygonMumbai,
       relayAdaptContract: RelayAdaptContract.PolygonMumbai,
       deploymentBlock: RailgunProxyDeploymentBlock.PolygonMumbai,
@@ -134,7 +128,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L2,
       },
-      fees: feeConfigL2(1.5),
       proxyContract: RailgunProxyContract.ArbitrumGoerli,
       relayAdaptContract: RelayAdaptContract.ArbitrumGoerli,
       deploymentBlock: RailgunProxyDeploymentBlock.ArbitrumGoerli,
@@ -150,7 +143,6 @@ const networksConfig: NetworksConfig = {
         decimals: 18,
         minBalanceForAvailability: MINIMUM_BALANCE_FOR_AVAILABILITY_L1,
       },
-      fees: feeConfigL1(1.25),
       proxyContract: RailgunProxyContract.Hardhat,
       relayAdaptContract: RelayAdaptContract.Hardhat,
       deploymentBlock: RailgunProxyDeploymentBlock.Hardhat,

--- a/src/server/config/config-token-sets.ts
+++ b/src/server/config/config-token-sets.ts
@@ -6,132 +6,169 @@ import {
   TokenAddressArbitrum,
 } from './config-token-addresses';
 
+import { feeConfigL1, feeConfigL2 } from './config-fees';
+
 export const STABLES_ETH: AddressToTokenMap = {
   [TokenAddressEthereum.USDT]: {
     symbol: 'USDT',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.DAI]: {
     symbol: 'DAI',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.USDC]: {
     symbol: 'USDC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.FRAX]: {
     symbol: 'FRAX',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.FEI]: {
     symbol: 'FEI',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.RAI]: {
     symbol: 'RAI',
+    fee: feeConfigL1(1.18),
   },
 };
 
 export const BLUECHIP_ETH: AddressToTokenMap = {
   [TokenAddressEthereum.WETH]: {
     symbol: 'WETH',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.WBTC]: {
     symbol: 'WBTC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.RAIL]: {
     symbol: 'RAIL',
+    fee: feeConfigL1(1.18),
   },
 };
 
 export const REN_TOKENS_ETH: AddressToTokenMap = {
   [TokenAddressEthereum.REN]: {
     symbol: 'REN',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.RENBTC]: {
     symbol: 'RENBTC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.RENZEC]: {
     symbol: 'RENZEC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.RENDOGE]: {
     symbol: 'RENDOGE',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressEthereum.RENFIL]: {
     symbol: 'RENFIL',
+    fee: feeConfigL1(1.18),
   },
 };
 
 export const BLUECHIP_BSC: AddressToTokenMap = {
   [TokenAddressBSC.WBNB]: {
     symbol: 'WETH',
+    fee: feeConfigL1(1.18),
   },
 
   [TokenAddressBSC.CAKE]: {
     symbol: 'CAKE',
+    fee: feeConfigL1(1.18),
   },
 };
 export const BLUECHIP_POLY: AddressToTokenMap = {
   [TokenAddressPolygonPOS.WETH]: {
     symbol: 'WETH',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressPolygonPOS.BNB]: {
     symbol: 'WETH',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressPolygonPOS.WMATIC]: {
     symbol: 'WMATIC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressPolygonPOS.WBTC]: {
     symbol: 'WBTC',
+    fee: feeConfigL1(1.18),
   },
 };
 export const STABLES_BSC: AddressToTokenMap = {
   [TokenAddressBSC.BUSD]: {
     symbol: 'BUSD',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressBSC.DAI]: {
     symbol: 'DAI',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressBSC.USDC]: {
     symbol: 'USDC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressBSC.USDT]: {
     symbol: 'USDT',
+    fee: feeConfigL1(1.18),
   },
 };
 export const STABLES_POLY: AddressToTokenMap = {
   [TokenAddressPolygonPOS.DAI]: {
     symbol: 'DAI',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressPolygonPOS.USDC]: {
     symbol: 'USDC',
+    fee: feeConfigL1(1.18),
   },
   [TokenAddressPolygonPOS.USDT]: {
     symbol: 'USDT',
+    fee: feeConfigL1(1.18),
   },
 };
 
 export const STABLES_ARBITRUM: AddressToTokenMap = {
   [TokenAddressArbitrum.USDT]: {
     symbol: 'USDT',
+    fee: feeConfigL2(1.8),
   },
   [TokenAddressArbitrum.USDC]: {
     symbol: 'USDC',
+    fee: feeConfigL2(1.8),
   },
   [TokenAddressArbitrum.DAI]: {
     symbol: 'DAI',
+    fee: feeConfigL2(1.8),
   },
   [TokenAddressArbitrum.TUSD]: {
     symbol: 'TUSD',
+    fee: feeConfigL2(1.8),
   },
 };
 
 export const BLUECHIP_ARBITRUM: AddressToTokenMap = {
   [TokenAddressArbitrum.UNI]: {
     symbol: 'UNI',
+    fee: feeConfigL2(1.8),
   },
   [TokenAddressArbitrum.FRAX]: {
     symbol: 'FRAX',
+    fee: feeConfigL2(1.8),
   },
   [TokenAddressArbitrum.WBTC]: {
     symbol: 'WBTC',
+    fee: feeConfigL2(1.8),
   },
   [TokenAddressArbitrum.WETH]: {
     symbol: 'WETH',
+    fee: feeConfigL2(1.8),
   },
 };

--- a/src/server/config/config-tokens.ts
+++ b/src/server/config/config-tokens.ts
@@ -17,6 +17,7 @@ import {
 } from './config-token-sets';
 import { NetworkChainID } from './config-chains';
 import { ChainType } from '@railgun-community/shared-models';
+import { feeConfigL1, feeConfigL2 } from './config-fees';
 
 /**
  *
@@ -39,9 +40,11 @@ const tokensConfig: NetworkTokensConfig = {
     [NetworkChainID.EthereumGoerli]: {
       [TokenAddressGoerli.WETH]: {
         symbol: 'WETH',
+        fee: feeConfigL1(1.17),
       },
       [TokenAddressGoerli.DAI]: {
         symbol: 'DAI',
+        fee: feeConfigL1(1.17),
       },
     },
     [NetworkChainID.BNBChain]: {
@@ -59,22 +62,27 @@ const tokensConfig: NetworkTokensConfig = {
     [NetworkChainID.PolygonMumbai]: {
       [TokenAddressPolygonMumbai.WMATIC]: {
         symbol: 'WMATIC',
+        fee: feeConfigL1(1.17),
       },
       [TokenAddressPolygonMumbai.DERC20]: {
         symbol: 'DERC20',
+        fee: feeConfigL1(1.17),
       },
     },
     [NetworkChainID.ArbitrumGoerli]: {
       [TokenAddressArbitrumGoerli.WETH]: {
         symbol: 'WETH',
+        fee: feeConfigL2(1.17),
       },
       [TokenAddressArbitrumGoerli.USDC]: {
         symbol: 'USDC',
+        fee: feeConfigL2(1.17),
       },
     },
     [NetworkChainID.Hardhat]: {
       '0x5FbDB2315678afecb367f032d93F642f64180aa3': {
         symbol: 'TESTERC20',
+        fee: feeConfigL1(1.17),
       },
     },
   },

--- a/src/server/fees/__tests__/calculate-token-fee.test.ts
+++ b/src/server/fees/__tests__/calculate-token-fee.test.ts
@@ -31,6 +31,7 @@ import {
   getEVMGasTypeForTransaction,
   NetworkName,
 } from '@railgun-community/shared-models';
+import { feeConfigL1 } from '../../config/config-fees';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -90,9 +91,11 @@ describe('calculate-token-fee', () => {
     configTokens[chain.type][chain.id] = {
       [MOCK_TOKEN_ADDRESS]: {
         symbol: 'MOCK1',
+        fee: feeConfigL1(1.1),
       },
       [MOCK_TOKEN_6_DECIMALS]: {
         symbol: 'MOCK2',
+        fee: feeConfigL1(1.1),
       },
     };
     await initTokens();

--- a/src/server/fees/__tests__/fee-validator.test.ts
+++ b/src/server/fees/__tests__/fee-validator.test.ts
@@ -19,6 +19,7 @@ import configTokens from '../../config/config-tokens';
 import { initTokens } from '../../tokens/network-tokens';
 import { ErrorMessage } from '../../../util/errors';
 import { testChainEthereum } from '../../../test/setup.test';
+import { feeConfigL1 } from '../../config/config-fees';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -53,6 +54,7 @@ describe('fee-validator', function test() {
     configTokens[MOCK_CHAIN.type][MOCK_CHAIN.id] = {};
     configTokens[MOCK_CHAIN.type][MOCK_CHAIN.id][MOCK_TOKEN_ADDRESS] = {
       symbol: 'TOKEN',
+      fee: feeConfigL1(1.1),
     };
     await initTokens();
   });

--- a/src/server/fees/calculate-token-fee.ts
+++ b/src/server/fees/calculate-token-fee.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'ethers';
 import configDefaults from '../config/config-defaults';
-import configNetworks from '../config/config-networks';
 import { GAS_TOKEN_DECIMALS, Token } from '../../models/token-models';
+
 import {
   allTokenAddressesForNetwork,
   getTransactionTokens,
@@ -60,7 +60,6 @@ const getTokenRatiosFromCachedPrices = (
   tokenAddress: string,
   precision: number,
 ) => {
-  const networkConfig = configNetworks[chain.type][chain.id];
   const { token, gasToken } = getTransactionTokens(chain, tokenAddress);
   const { tokenPrice, gasTokenPrice } = getTransactionTokenPrices(
     chain,
@@ -71,7 +70,7 @@ const getTokenRatiosFromCachedPrices = (
   const roundedPriceRatio = getRoundedTokenToGasPriceRatio(
     tokenPrice,
     gasTokenPrice,
-    networkConfig.fees,
+    token.fee,
     precision,
   );
   const decimalRatio = getTransactionTokenToGasDecimalRatio(token);

--- a/src/server/fees/legacy/__tests__/calculate-transaction-gas-legacy.test.ts
+++ b/src/server/fees/legacy/__tests__/calculate-transaction-gas-legacy.test.ts
@@ -61,10 +61,10 @@ describe('calculate-transaction-gas-legacy', () => {
     mockTokenConfig(MOCK_CHAIN, MOCK_TOKEN_6_DECIMALS);
     await initTokens();
     configNetworks[MOCK_CHAIN.type][MOCK_CHAIN.id] = getMockNetwork();
-    configNetworks[MOCK_CHAIN.type][
-      MOCK_CHAIN.id
-    ].fees.gasEstimateVarianceBuffer = 0.05;
-    configNetworks[MOCK_CHAIN.type][MOCK_CHAIN.id].fees.profit = 0.05;
+    // configNetworks[MOCK_CHAIN.type][
+    //   MOCK_CHAIN.id
+    // ].fees.gasEstimateVarianceBuffer = 0.05;
+    // configNetworks[MOCK_CHAIN.type][MOCK_CHAIN.id].fees.profit = 0.05;
     await initNetworkProviders();
     cacheTokenPriceForNetwork(
       TokenPriceSource.CoinGecko,

--- a/src/server/fees/legacy/calculate-transaction-gas-legacy.ts
+++ b/src/server/fees/legacy/calculate-transaction-gas-legacy.ts
@@ -5,7 +5,6 @@ import {
 import { BigNumber } from 'ethers';
 import { RelayerChain } from '../../../models/chain-models';
 import configDefaults from '../../config/config-defaults';
-import configNetworks from '../../config/config-networks';
 import { getTransactionTokens } from '../../tokens/network-tokens';
 import { getTransactionTokenPrices } from '../../tokens/token-price-cache';
 import {
@@ -33,12 +32,12 @@ export const createTransactionGasDetailsLegacy = (
     gasToken,
   );
 
-  const networkConfig = configNetworks[chain.type][chain.id];
+  // const networkConfig = configNetworks[chain.type][chain.id];
   const { precision } = configDefaults.transactionFees;
   const roundedRatio = getRoundedTokenToGasPriceRatio(
     tokenPrice,
     gasTokenPrice,
-    networkConfig.fees,
+    token.fee, // networkConfig.fees,
     precision,
   );
   const decimalRatio = getTransactionTokenToGasDecimalRatio(token);

--- a/src/server/networking/__tests__/waku-api-client.test.ts
+++ b/src/server/networking/__tests__/waku-api-client.test.ts
@@ -12,6 +12,7 @@ import { resetTokenPriceCache } from '../../tokens/token-price-cache';
 import { resetTransactionFeeCache } from '../../fees/transaction-fee-cache';
 import configTokens from '../../config/config-tokens';
 import { initTokens } from '../../tokens/network-tokens';
+import { feeConfigL1 } from '../../config/config-fees';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -30,6 +31,7 @@ describe('waku-api-client', () => {
     await setupSingleTestWallet();
     configTokens[MOCK_CHAIN.type][MOCK_CHAIN.id][MOCK_TOKEN_ADDRESS] = {
       symbol: 'MOCK1',
+      fee: feeConfigL1(1.1),
     };
     await initTokens();
 

--- a/src/server/tokens/__tests__/network-tokens.test.ts
+++ b/src/server/tokens/__tests__/network-tokens.test.ts
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { testChainEthereum } from '../../../test/setup.test';
 import configTokens from '../../config/config-tokens';
 import { allTokenAddressesForNetwork, initTokens } from '../network-tokens';
+import { feeConfigL1 } from '../../config/config-fees';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -16,6 +17,7 @@ describe('network-tokens', () => {
     configTokens[MOCK_CHAIN.type][MOCK_CHAIN.id] = {
       '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2': {
         symbol: 'WETH',
+        fee: feeConfigL1(1.1),
       },
     };
     await initTokens();

--- a/src/server/tokens/network-tokens.ts
+++ b/src/server/tokens/network-tokens.ts
@@ -45,13 +45,14 @@ const erc20TokenDetailsForAddress = async (
   provider: FallbackProvider,
   chain: RelayerChain,
 ): Promise<Optional<Token>> => {
-  const { symbol } = configTokens[chain.type][chain.id][tokenAddress];
+  const { symbol, fee } = configTokens[chain.type][chain.id][tokenAddress];
   try {
     const decimals = await getERC20Decimals(tokenAddress, provider);
     return {
       symbol,
       address: tokenAddress,
       decimals,
+      fee,
     };
   } catch (err) {
     logger.warn(

--- a/src/server/waku-relayer/__tests__/waku-relayer.test.ts
+++ b/src/server/waku-relayer/__tests__/waku-relayer.test.ts
@@ -67,6 +67,7 @@ import {
   getRailgunWalletAddress,
   getRailgunWalletID,
 } from '../../wallets/active-wallets';
+import { feeConfigL1 } from '../../config/config-fees';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -102,6 +103,7 @@ describe('waku-relayer', () => {
     configTokens[chain.type][chain.id] = {};
     configTokens[chain.type][chain.id][MOCK_TOKEN_ADDRESS] = {
       symbol: 'MOCK1',
+      fee: feeConfigL1(1.1),
     };
     await initTokens();
     processTransactionStub = sinon

--- a/src/test/mocks.test.ts
+++ b/src/test/mocks.test.ts
@@ -11,12 +11,14 @@ import { Network } from '../models/network-models';
 import { FallbackProviderJsonConfig } from '../models/provider-models';
 import { Token, TokenConfig } from '../models/token-models';
 import { RelayerChain } from '../models/chain-models';
+import { feeConfigL1 } from 'server/config/config-fees';
 
 export const mockTokenConfig = (chain: RelayerChain, tokenAddress: string) => {
   // @ts-ignore
   configTokens[chain.type] ??= {};
   configTokens[chain.type][chain.id][tokenAddress] = {
     symbol: tokenAddress.toUpperCase(),
+    fee: feeConfigL1(1),
   };
 };
 
@@ -69,11 +71,7 @@ export const getMockNetwork = (): Network => {
       decimals: 18,
       minBalanceForAvailability: 0.1,
     },
-    fees: {
-      gasEstimateVarianceBuffer: 0.03,
-      gasEstimateLimitToActualRatio: 1.25,
-      profit: 0.07,
-    },
+
     proxyContract: '0x00' as RailgunProxyContract,
     relayAdaptContract: '0x00' as RelayAdaptContract,
     coingeckoNetworkId: CoingeckoNetworkID.Ethereum,
@@ -91,11 +89,7 @@ export const getMockGoerliNetwork = (): Network => {
       decimals: 18,
       minBalanceForAvailability: 0.1,
     },
-    fees: {
-      gasEstimateVarianceBuffer: 0.05,
-      gasEstimateLimitToActualRatio: 1.25,
-      profit: 0.05,
-    },
+
     proxyContract: RailgunProxyContract.EthereumGoerli,
     relayAdaptContract: RelayAdaptContract.EthereumGoerli,
     fallbackProviderConfig: getMockGoerliFallbackProviderConfig(),
@@ -115,6 +109,7 @@ export const getMockSerializedTransaction = (): string => {
 export const getMockTokenConfig = (): TokenConfig => {
   return {
     symbol: 'SHIB',
+    fee: feeConfigL1(1.18),
   };
 };
 
@@ -123,6 +118,7 @@ export const getMockToken = (): Token => {
     address: '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE',
     symbol: 'SHIB',
     decimals: 18,
+    fee: feeConfigL1(1.18),
   };
 };
 


### PR DESCRIPTION
Adds the ability to control fees by token instead of by chain.
Seems unnecessary as of now with the 15% baseline as a desired fee.
I suppose this could just live as a branch to merge if chosen to use? 

in summary:
It just moves the 'fees' object from the networkConfig to be directly attached to each token as a 'fee' parameter.


Most of the changes are within adding the fee to each 'default' token.



